### PR TITLE
Build with catkin build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "thirdparty/godot-cpp"]
 	path = thirdparty/godot-cpp
-	url = https://github.com/GodotNativeTools/godot-cpp.git
+	url = https://github.com/godotengine/godot-cpp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ catkin_package()
 
 find_package(OpenCV REQUIRED)
 
+add_subdirectory(thirdparty/godot-cpp)
+
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
@@ -36,7 +38,8 @@ add_library(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
   ${OpenCV_LIBS}
-  ${PROJECT_SOURCE_DIR}/thirdparty/godot-cpp/bin/libgodot-cpp.linux.debug.64.a)
+  godot-cpp
+)
 
 set_target_properties(${PROJECT_NAME}
   PROPERTIES

--- a/src/gdlibrary.cpp
+++ b/src/gdlibrary.cpp
@@ -1,11 +1,15 @@
 #include "godot_ros_pcviz.hpp"
 
-int dummy_argc = 1;
-char *dummy_argv[] = {"godot_ros_pcviz"};
-
 extern "C" void GDN_EXPORT godot_gdnative_init(godot_gdnative_init_options *o) {
     godot::Godot::gdnative_init(o);
-    ros::init(dummy_argc, dummy_argv, "godot_ros_pcviz");
+    std::vector<std::string> arguments = {"godot_ros_pcviz"};
+    std::vector<char*> argv;
+    for (const auto& arg : arguments) {
+      argv.push_back((char*)arg.data());
+    }
+    argv.push_back(nullptr);
+    int argc = arguments.size();
+    ros::init(argc, argv.data(), "godot_ros_pcviz");
 }
 
 extern "C" void GDN_EXPORT godot_gdnative_terminate(godot_gdnative_terminate_options *o) {


### PR DESCRIPTION
Build fully with catkin build (and probably catkin_make, haven't tried it).

The project.godot ends up in `catkin_ws/devel/lib/godot_ros_pcviz/project.godot`.


Can rerun `catkin build godot_ros_pcviz` after making changes to godot_ros_pcviz.cpp then restart the project within the godot gui to see the results.

Something to do next is to support installation through catkin- all these files need to go into appropriate ros install locations:
```
default_env.tres
godot_ros_pcviz.gdnlib
godot_ros_pcviz.gdns
ImmediateGeometry.tscn
libgodot_ros_pcviz.so
Main.tscn
PointCloud.tscn
project.godot
```